### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install using [Bower](http://bower.io):
  bower install flip-clock
 ```
 
-##test
+## test
 
 Install [web-component-tester](https://github.com/Polymer/web-component-tester) globally
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
